### PR TITLE
Fix string format bug

### DIFF
--- a/FOVERecorder0.cs
+++ b/FOVERecorder0.cs
@@ -420,10 +420,11 @@ public class FOVERecorder0 : MonoBehaviour
                         datum.rightGaze.origin.z.ToString(vPrecision),
                         datum.rightGaze.direction.x.ToString(vPrecision),
                         datum.rightGaze.direction.y.ToString(vPrecision),
-                        datum.rightGaze.direction.z.ToString(vPrecision));
-                        datum.isLookingAtObject.ToString();// is looking at object 1493
-                        datum.shapeName.ToString(); // object identification 1493
-                        datum.shapeLocation.ToString(); // object location 1493
+                        datum.rightGaze.direction.z.ToString(vPrecision),
+                        datum.isLookingAtObject.ToString(),// is looking at object 1493
+                        datum.shapeName, // object identification 1493
+                        datum.shapeLocation.ToString() // object location 1493
+                    );
                 }
 
                 File.AppendAllText(fileName, text);


### PR DESCRIPTION
Fixed copy-paste bug with a closing parenthesis and semicolons that was making the `strong.Format(...)` end too soon and the remaining `ToStrings()` were just being called and having their results discarded immediately.

I also moved the closing parenthesis a line down so it's a bit easier to see and should help prevent this kind of bug in the future.